### PR TITLE
Bump goose-ai version to latest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "ai-exchange>=0.8.4",
-    "goose-ai>=0.9.0",
+    "goose-ai>=0.9.8",
 ]
 author = [{ name = "Block", email = "ai-oss-tools@block.xyz" }]
 packages = [{ include = "goose_plugins", from = "src" }]


### PR DESCRIPTION
Bumping goose-ai to latest version to see if it resolve build issues installing goose-plugins via pipx.